### PR TITLE
Add HTML KPI templates for cost dashboards

### DIFF
--- a/templates/kpi-custos/README.md
+++ b/templates/kpi-custos/README.md
@@ -1,0 +1,17 @@
+# Templates HTML de KPI de Custos para Power BI Desktop
+
+Dois cartões prontos para serem utilizados com visuais que renderizam HTML no Power BI (ex.: HTML Content, DAX HTML ou Deneb com Markdown). Basta substituir os valores de exemplo pelos campos ou medidas do seu modelo.
+
+## Como usar
+1. Copie o conteúdo de um dos arquivos `.html`.
+2. Troque os textos de exemplo pelos seus campos do Power BI (por exemplo, use medidas formatadas em DAX via `VALUE()` ou `FORMAT()` dentro do HTML).
+3. Se o visual aceitar parâmetros dinâmicos, altere as porcentagens das barras (`width`) e os números dos elementos `id` (`valor-principal`, `meta`, `atingimento`, `delta`, `fonte`, `ticket`) com as medidas do relatório.
+4. Cole o HTML final no visual escolhido.
+
+### Dicas rápidas
+- Mantenha os símbolos (ex.: `▼` ou `▲`) para indicar direção e altere a classe `negative` em `.delta` quando a variação for desfavorável.
+- Ajuste a largura dos cartões via CSS (`width`) para caber em diferentes layouts do dashboard.
+
+## Arquivos disponíveis
+- `cartao-custo-essencial.html`: cartão com foco em valor total, meta, atingimento e variação mensal, com progress bar.
+- `cartao-custo-compacto.html`: versão mais compacta para custo operacional, destacando YoY e ticket médio.

--- a/templates/kpi-custos/cartao-custo-compacto.html
+++ b/templates/kpi-custos/cartao-custo-compacto.html
@@ -1,0 +1,142 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI de Custos - Cartão Compacto</title>
+  <style>
+    :root {
+      --fundo: #0b1021;
+      --painel: #12182b;
+      --borda: rgba(255, 255, 255, 0.08);
+      --texto-principal: #f3f4f6;
+      --texto-suave: #cbd5e1;
+      --alto: #60a5fa;
+      --barra-fundo: rgba(255, 255, 255, 0.06);
+      --positivo: #10b981;
+      --negativo: #ef4444;
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: "Segoe UI", "Inter", system-ui, -apple-system, sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--fundo);
+      color: var(--texto-principal);
+      padding: 10px;
+    }
+
+    .card {
+      width: 280px;
+      background: var(--painel);
+      border: 1px solid var(--borda);
+      border-radius: 14px;
+      padding: 14px 14px 12px;
+      box-shadow: 0 10px 24px rgba(0, 0, 0, 0.28);
+    }
+
+    .topo {
+      display: flex;
+      justify-content: space-between;
+      align-items: flex-start;
+      margin-bottom: 10px;
+    }
+
+    .titulo {
+      display: grid;
+      gap: 4px;
+    }
+
+    .chapeu {
+      text-transform: uppercase;
+      font-size: 12px;
+      letter-spacing: 0.35px;
+      color: var(--texto-suave);
+    }
+
+    .valor {
+      font-size: 26px;
+      font-weight: 700;
+      letter-spacing: -0.3px;
+    }
+
+    .delta {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 10px;
+      background: rgba(16, 185, 129, 0.12);
+      color: var(--positivo);
+      border: 1px solid rgba(16, 185, 129, 0.3);
+      font-size: 12px;
+    }
+
+    .delta.negative {
+      background: rgba(239, 68, 68, 0.12);
+      color: var(--negativo);
+      border-color: rgba(239, 68, 68, 0.3);
+    }
+
+    .detalhes {
+      display: grid;
+      gap: 6px;
+      color: var(--texto-suave);
+      font-size: 13px;
+    }
+
+    .barra-meta {
+      position: relative;
+      height: 8px;
+      background: var(--barra-fundo);
+      border-radius: 999px;
+      overflow: hidden;
+      border: 1px solid var(--borda);
+    }
+
+    .preenchimento {
+      height: 100%;
+      width: 82%; /* Substitua pelo atingimento */
+      background: linear-gradient(90deg, #3b82f6, #60a5fa);
+    }
+
+    .linha {
+      display: flex;
+      justify-content: space-between;
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="topo">
+      <div class="titulo">
+        <span class="chapeu">Custo Operacional</span>
+        <span class="valor" id="valor-principal">R$ 187,5 mil</span>
+      </div>
+      <div id="delta" class="delta">▲ 5,2% YoY</div>
+    </div>
+
+    <div class="detalhes">
+      <div class="linha">
+        <span>Meta mensal</span>
+        <strong id="meta">R$ 230 mil</strong>
+      </div>
+      <div class="barra-meta">
+        <div class="preenchimento" style="width: 82%"></div>
+      </div>
+      <div class="linha">
+        <span>Ticket médio</span>
+        <strong id="ticket">R$ 1.420</strong>
+      </div>
+      <div class="linha">
+        <span>Fonte</span>
+        <strong id="fonte">Sistema ERP / Dataflow</strong>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/templates/kpi-custos/cartao-custo-essencial.html
+++ b/templates/kpi-custos/cartao-custo-essencial.html
@@ -1,0 +1,170 @@
+<!DOCTYPE html>
+<html lang="pt-BR">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>KPI de Custos - Cartão Essencial</title>
+  <style>
+    :root {
+      --fundo: #0f172a;
+      --painel: #111827;
+      --texto-principal: #e5e7eb;
+      --texto-secundario: #9ca3af;
+      --positivo: #34d399;
+      --negativo: #f87171;
+      --borda: rgba(255, 255, 255, 0.08);
+      --gradiente: linear-gradient(135deg, #1f2937, #0f172a 55%);
+    }
+
+    * {
+      box-sizing: border-box;
+      font-family: "Segoe UI", "Inter", system-ui, -apple-system, sans-serif;
+      margin: 0;
+      padding: 0;
+    }
+
+    body {
+      background: var(--fundo);
+      color: var(--texto-principal);
+      padding: 8px;
+    }
+
+    .card {
+      width: 320px;
+      background: var(--gradiente);
+      border: 1px solid var(--borda);
+      border-radius: 16px;
+      box-shadow: 0 12px 40px rgba(0, 0, 0, 0.35);
+      padding: 16px 18px 14px;
+    }
+
+    .header {
+      display: flex;
+      align-items: center;
+      gap: 10px;
+      margin-bottom: 6px;
+    }
+
+    .icon {
+      width: 36px;
+      height: 36px;
+      display: grid;
+      place-items: center;
+      border-radius: 10px;
+      background: rgba(255, 255, 255, 0.04);
+      border: 1px solid var(--borda);
+      font-size: 18px;
+    }
+
+    .title {
+      display: flex;
+      flex-direction: column;
+      gap: 2px;
+    }
+
+    .label {
+      font-size: 13px;
+      letter-spacing: 0.35px;
+      text-transform: uppercase;
+      color: var(--texto-secundario);
+    }
+
+    .value {
+      font-size: 30px;
+      font-weight: 700;
+      letter-spacing: -0.5px;
+      display: flex;
+      align-items: baseline;
+      gap: 6px;
+    }
+
+    .badge {
+      font-size: 12px;
+      padding: 4px 8px;
+      border-radius: 999px;
+      border: 1px solid var(--borda);
+      color: var(--texto-secundario);
+      background: rgba(255, 255, 255, 0.03);
+    }
+
+    .meta {
+      display: flex;
+      justify-content: space-between;
+      align-items: center;
+      margin: 10px 0 6px;
+      color: var(--texto-secundario);
+      font-size: 13px;
+    }
+
+    .progress {
+      position: relative;
+      height: 10px;
+      background: rgba(255, 255, 255, 0.06);
+      border-radius: 999px;
+      overflow: hidden;
+      border: 1px solid var(--borda);
+    }
+
+    .progress-fill {
+      height: 100%;
+      width: 64%; /* Substitua pela % do atingimento */
+      background: linear-gradient(90deg, #34d399, #10b981);
+    }
+
+    .footer {
+      display: flex;
+      justify-content: space-between;
+      align-items: baseline;
+      margin-top: 10px;
+      font-size: 13px;
+      color: var(--texto-secundario);
+    }
+
+    .delta {
+      display: inline-flex;
+      align-items: center;
+      gap: 6px;
+      padding: 6px 10px;
+      border-radius: 10px;
+      background: rgba(52, 211, 153, 0.1);
+      color: var(--positivo);
+      border: 1px solid rgba(52, 211, 153, 0.3);
+    }
+
+    .delta.negative {
+      background: rgba(248, 113, 113, 0.1);
+      color: var(--negativo);
+      border-color: rgba(248, 113, 113, 0.35);
+    }
+  </style>
+</head>
+<body>
+  <div class="card">
+    <div class="header">
+      <div class="icon">💰</div>
+      <div class="title">
+        <span class="label">Custo Total</span>
+        <div class="value">
+          <span id="valor-principal">R$ 2,34 Mi</span>
+          <span class="badge">Atualizado: Out/2024</span>
+        </div>
+      </div>
+    </div>
+
+    <div class="meta">
+      <span>Meta: <strong id="meta">R$ 2,5 Mi</strong></span>
+      <span>Atingimento <strong id="atingimento">64%</strong></span>
+    </div>
+    <div class="progress">
+      <div class="progress-fill" style="width: 64%"></div>
+    </div>
+
+    <div class="footer">
+      <div id="delta" class="delta">
+        <span>▼ -3,8% vs mês anterior</span>
+      </div>
+      <span id="fonte">Fonte: ERP Financeiro</span>
+    </div>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add two HTML KPI card templates focused em custos para uso em visuais HTML do Power BI
- documenta como substituir valores e ajustar medidas dinamicamente nos cartões

## Testing
- not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69304ead28cc832a92b04a5728d08e51)